### PR TITLE
Fixed FormatException when nan/-nan is parsed.

### DIFF
--- a/LibMPlayerCommon/Globals.cs
+++ b/LibMPlayerCommon/Globals.cs
@@ -37,6 +37,9 @@ namespace LibMPlayerCommon
 
         public static float FloatParse(string input)
         {
+            input = input.Trim();
+            if (input.Equals("nan", StringComparison.OrdinalIgnoreCase) || input.Equals("-nan", StringComparison.OrdinalIgnoreCase)) { return float.NaN; }
+
             return float.Parse(input.Replace(",", "."), System.Globalization.CultureInfo.InvariantCulture);
         }
 


### PR DESCRIPTION
Some mp4 cause FloatParse to be called with "-nan"/"nan"/" -nan"/"nan" (e.g. http://video.ch9.ms/sessions/build/2014/2-577_mobile.mp4).

Unfortunately Mono cannot parse nan unless it is exact literal "NaN". This code is a workaround for this.
## Example exception:

libGL error: pci id for fd 5: 80ee:beef, driver (null)
System.FormatException: Unknown char: n
  at System.Double.Parse (System.String s, NumberStyles style, IFormatProvider provider) [0x00000] in <filename unknown>:0 
  at System.Single.Parse (System.String s, IFormatProvider provider) [0x00000] in <filename unknown>:0 
  at LibMPlayerCommon.Globals.FloatParse (System.String input) [0x00000] in <filename unknown>:0 
  at LibMPlayerCommon.Discover..ctor (System.String filePath, System.String mplayerPath) [0x00000] in <filename unknown>:0 
  at LibMPlayerCommon.MPlayer.LoadCurrentPlayingFileLength () [0x00000] in <filename unknown>:0 
  at LibMPlayerCommon.MPlayer.LoadFile (System.String filePath) [0x00000] in <filename unknown>:0 
  at LibMPlayerCommon.MPlayer.Play (System.String filePath) [0x00000] in <filename unknown>:0 
  at Test.MainForm.<MainForm>m__0 (System.Object sender, System.EventArgs e) [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.Form.OnLoad (System.EventArgs e) [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.Form.OnLoadInternal (System.EventArgs e) [0x00000] in <filename unknown>:0 

Unhandled Exception:
System.ObjectDisposedException: The object was used after being disposed.
  at System.Windows.Forms.Control.CreateHandle () [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.Form.CreateHandle () [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.Control.get_Handle () [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.Control:get_Handle ()
  at System.Windows.Forms.Form.SetVisibleCore (Boolean value) [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.Control.set_Visible (Boolean value) [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.Control:set_Visible (bool)
  at System.Windows.Forms.Application.RunLoop (Boolean Modal, System.Windows.Forms.ApplicationContext context) [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.Application.Run (System.Windows.Forms.ApplicationContext context) [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.Application.Run (System.Windows.Forms.Form mainForm) [0x00000] in <filename unknown>:0 
  at Test.App.Main (System.String[] args) [0x00000] in <filename unknown>:0 
[ERROR] FATAL UNHANDLED EXCEPTION: System.ObjectDisposedException: The object was used after being disposed.
  at System.Windows.Forms.Control.CreateHandle () [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.Form.CreateHandle () [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.Control.get_Handle () [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.Control:get_Handle ()
  at System.Windows.Forms.Form.SetVisibleCore (Boolean value) [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.Control.set_Visible (Boolean value) [0x00000] in <filename unknown>:0 
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.Control:set_Visible (bool)
  at System.Windows.Forms.Application.RunLoop (Boolean Modal, System.Windows.Forms.ApplicationContext context) [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.Application.Run (System.Windows.Forms.ApplicationContext context) [0x00000] in <filename unknown>:0 
  at System.Windows.Forms.Application.Run (System.Windows.Forms.Form mainForm) [0x00000] in <filename unknown>:0 
  at Test.App.Main (System.String[] args) [0x00000] in <filename unknown>:0 
