### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,5 +1,8 @@
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/majorsilence/MPlayerControl/security/code-scanning/2](https://github.com/majorsilence/MPlayerControl/security/code-scanning/2)

In general, to fix this issue you add an explicit `permissions:` section either at the top level of the workflow (applies to all jobs) or within each job, and set it to the least privileges necessary. For a build-and-test workflow that only checks out code and runs `dotnet` commands, read access to repository contents is sufficient, and no explicit write scopes are needed.

The best fix here, without changing existing functionality, is to add a top-level `permissions:` block after the `name:` (or after `on:`) setting `contents: read`. This will apply to both `windows-build` and `linux-build` jobs, and ensures that `GITHUB_TOKEN` is limited to read-only content access. No job appears to require write access to PRs, issues, or packages, so we do not need to grant any additional scopes.

Concretely, in `.github/workflows/dotnet.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file, at the root level (aligned with `name:` and `on:`). No imports or additional methods are required, since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
